### PR TITLE
feat: add optional group budget with progress tracking

### DIFF
--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -41,6 +41,7 @@ function toGroup(row) {
     name: row.name,
     createdBy: row.created_by,
     createdAt: new Date(row.created_at).getTime(),
+    budget: row.budget ?? null,
     members: (row.group_members ?? []).map((m) => ({
       userId: m.user_id,
       email: m.email,
@@ -107,7 +108,7 @@ export const storage = {
     const { data: groups } = await supabase
       .from("groups")
       .select(
-        "id, name, created_by, created_at, group_members(user_id, email, name, status)",
+        "id, name, created_by, created_at, budget, group_members(user_id, email, name, status)",
       )
       .in("id", groupIds);
     _groups = (groups ?? []).map(toGroup);
@@ -174,7 +175,7 @@ export const storage = {
     return _groups.filter((g) => g.members.some((m) => m.userId === userId));
   },
 
-  createGroup({ name, createdBy, memberEmails }) {
+  createGroup({ name, createdBy, memberEmails, budget = null }) {
     const creator = this.getUserById(createdBy);
     if (!creator) throw new Error("Creator not found");
 
@@ -204,11 +205,15 @@ export const storage = {
       );
     }
 
+    const normalizedBudget =
+      budget && Number(budget) > 0 ? Number(budget) : null;
+
     const group = {
       id: crypto.randomUUID(),
       name: name.trim(),
       createdBy,
       createdAt: Date.now(),
+      budget: normalizedBudget,
       members,
     };
     _groups.push(group);
@@ -226,6 +231,7 @@ export const storage = {
       name: group.name,
       created_by: group.createdBy,
       created_at: new Date(group.createdAt).toISOString(),
+      budget: group.budget ?? null,
     });
     if (gErr) throw gErr;
 
@@ -346,6 +352,23 @@ export const storage = {
     if (error) throw error;
 
     group.name = trimmed;
+  },
+
+  // Update a group's budget — updates the `groups` table and in-memory cache.
+  // Pass null (or 0 / empty) to remove the budget.
+  async updateGroupBudget(groupId, budget) {
+    const normalized = budget && Number(budget) > 0 ? Number(budget) : null;
+
+    const group = _groups.find((g) => g.id === groupId);
+    if (!group) throw new Error("Group not found.");
+
+    const { error } = await supabase
+      .from("groups")
+      .update({ budget: normalized })
+      .eq("id", groupId);
+    if (error) throw error;
+
+    group.budget = normalized;
   },
 
   // Remove a member from a group — deletes from `group_members` and removes

--- a/src/pages/CreateGroup.jsx
+++ b/src/pages/CreateGroup.jsx
@@ -9,6 +9,7 @@ export default function CreateGroup() {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [name, setName] = useState("");
+  const [budget, setBudget] = useState("");
   const [emailInput, setEmailInput] = useState("");
   const [members, setMembers] = useState([]); // [{ email, registered, name? }]
   const [error, setError] = useState("");
@@ -48,10 +49,12 @@ export default function CreateGroup() {
       setError("Group name is required.");
       return;
     }
+    const parsedBudget = parseFloat(budget);
     const group = storage.createGroup({
       name,
       createdBy: user.id,
       memberEmails: members.map((m) => m.email),
+      budget: !isNaN(parsedBudget) && parsedBudget > 0 ? parsedBudget : null,
     });
     navigate(`/group/${group.id}`);
   }
@@ -83,6 +86,22 @@ export default function CreateGroup() {
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Goa trip, Apartment 3B…"
                 autoFocus
+                className="field"
+              />
+            </label>
+
+            <label className="block">
+              <span className="field-label">
+                Budget{" "}
+                <span className="font-normal text-ink-muted">(optional)</span>
+              </span>
+              <input
+                type="number"
+                min="0"
+                step="any"
+                value={budget}
+                onChange={(e) => setBudget(e.target.value)}
+                placeholder="e.g. 20000"
                 className="field"
               />
             </label>

--- a/src/pages/GroupDetail.jsx
+++ b/src/pages/GroupDetail.jsx
@@ -132,6 +132,9 @@ export default function GroupDetail() {
 
           {/* Right column — balance summary on top, members below */}
           <div className="flex flex-col gap-5 lg:col-span-2">
+            {group.budget > 0 && (
+              <BudgetCard expenses={expenses} budget={group.budget} />
+            )}
             <BalanceSummary
               settlements={settlements}
               currentUserId={user.id}
@@ -161,6 +164,43 @@ export default function GroupDetail() {
         />
       )}
     </div>
+  );
+}
+
+function BudgetCard({ expenses, budget }) {
+  const totalSpent = expenses.reduce((sum, e) => sum + e.amount, 0);
+  const remaining = budget - totalSpent;
+  const pct = Math.min((totalSpent / budget) * 100, 100);
+  const isOverBudget = totalSpent > budget;
+
+  return (
+    <section className="card space-y-3">
+      <SectionLabel>Budget</SectionLabel>
+      <p className="text-sm text-ink-soft">
+        <span className="font-semibold tabular-nums text-ink">
+          {formatCurrency(totalSpent)}
+        </span>{" "}
+        spent of {formatCurrency(budget)}
+      </p>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-line">
+        <div
+          className="h-2 rounded-full transition-all duration-300"
+          style={{
+            width: `${pct}%`,
+            backgroundColor: isOverBudget
+              ? "var(--color-neg)"
+              : "var(--color-brand)",
+          }}
+        />
+      </div>
+      <p
+        className={`text-sm font-medium ${isOverBudget ? "text-neg" : "text-pos"}`}
+      >
+        {isOverBudget
+          ? `Over budget by ${formatCurrency(Math.abs(remaining))}`
+          : `${formatCurrency(remaining)} remaining`}
+      </p>
+    </section>
   );
 }
 

--- a/src/pages/GroupSettings.jsx
+++ b/src/pages/GroupSettings.jsx
@@ -42,6 +42,7 @@ export default function GroupSettings() {
         </div>
 
         <RenameSection group={group} onRenamed={refresh} />
+        <BudgetSection group={group} onUpdate={refresh} />
         <MembersSection
           group={group}
           currentUserId={user.id}
@@ -113,6 +114,78 @@ function RenameSection({ group, onRenamed }) {
           className="btn-primary disabled:opacity-60"
         >
           {status === "saving" ? "Saving…" : "Save name"}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Budget section
+// ---------------------------------------------------------------------------
+
+function BudgetSection({ group, onUpdate }) {
+  const [budgetValue, setBudgetValue] = useState(
+    group.budget != null ? String(group.budget) : "",
+  );
+  const [status, setStatus] = useState(null); // null | 'saving' | 'success' | 'error'
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const parsed = parseFloat(budgetValue);
+    const normalized =
+      budgetValue.trim() === "" || isNaN(parsed) || parsed <= 0 ? null : parsed;
+    setStatus("saving");
+    setErrorMsg("");
+    try {
+      await storage.updateGroupBudget(group.id, normalized);
+      setStatus("success");
+      onUpdate();
+      setTimeout(() => setStatus(null), 3000);
+    } catch (err) {
+      setErrorMsg(err.message || "Failed to update budget. Please try again.");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <section className="card space-y-4">
+      <SectionLabel>Budget</SectionLabel>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <label className="block">
+          <span className="field-label">
+            Total budget{" "}
+            <span className="font-normal text-ink-muted">(optional)</span>
+          </span>
+          <input
+            type="number"
+            min="0"
+            step="any"
+            value={budgetValue}
+            onChange={(e) => {
+              setBudgetValue(e.target.value);
+              setStatus(null);
+            }}
+            placeholder="e.g. 20000"
+            className="field"
+          />
+        </label>
+        <p className="text-sm text-ink-muted">
+          Leave empty to remove the budget.
+        </p>
+        {status === "error" && (
+          <p className="text-sm text-danger">{errorMsg}</p>
+        )}
+        {status === "success" && (
+          <p className="text-sm text-pos">Budget updated successfully.</p>
+        )}
+        <button
+          type="submit"
+          disabled={status === "saving"}
+          className="btn-primary disabled:opacity-60"
+        >
+          {status === "saving" ? "Saving…" : "Save budget"}
         </button>
       </form>
     </section>


### PR DESCRIPTION
## Summary

- Groups can now have an optional total budget (e.g. \$20,000) set at creation or updated any time via Group Settings (admin only)
- GroupDetail shows a budget card in the right column: spent vs. total, an animated progress bar, and a remaining/over-budget line
- Progress bar is brand orange while under budget and turns red when spending exceeds the budget
- Budget is stored as `NUMERIC` on the `groups` table; null or zero is treated as "not set" and hides all budget UI

## What changed

| File | Change |
|---|---|
| `src/data/storage.js` | `toGroup`, `init` select, `createGroup`, `_persistGroup` updated; new `updateGroupBudget` method |
| `src/pages/CreateGroup.jsx` | Optional Budget field added between Group name and Add members |
| `src/pages/GroupSettings.jsx` | New `BudgetSection` component (admin only, between Rename and Members) |
| `src/pages/GroupDetail.jsx` | New `BudgetCard` component in right column, above Balances |

## Manual test plan

- [ ] **Create with budget** — create a new group, enter `20000` in the Budget field → navigate to GroupDetail, verify the budget card appears showing `$0.00 spent of $20,000.00` with an empty bar and `$20,000.00 remaining`
- [ ] **Create without budget** — create a group leaving Budget empty → verify no budget card appears in GroupDetail
- [ ] **Add expenses (under budget)** — add expenses totalling less than the budget → verify the orange bar grows and remaining decreases correctly
- [ ] **Over-budget state** — add expenses that exceed the budget → verify bar turns red and shows `Over budget by $X`
- [ ] **Edit budget in Group Settings** — open Settings as admin, change the budget value, save → verify "Saved!" feedback and GroupDetail reflects the new amount
- [ ] **Remove budget** — clear the budget field in Group Settings and save → verify the budget card disappears from GroupDetail
- [ ] **Budget = 0 normalization** — save `0` in Group Settings → verify it is treated as null (card disappears)
- [ ] **Delete all expenses** — on a group with a budget, delete every expense → verify card shows `$0.00 spent` with an empty bar and full remaining amount
- [ ] **Non-admin view** — log in as a non-admin member → verify Budget section does not appear in Group Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)