### PR TITLE
fix(profile): restore Avatar initials as photo fallback

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -4,6 +4,7 @@ import { storage } from "../data/storage";
 import { useAuth } from "../context/useAuth";
 import { formatDate } from "../lib/format";
 import AppHeader from "../components/AppHeader";
+import Avatar from "../components/Avatar";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -218,11 +219,15 @@ export default function Profile() {
           {/* Avatar + change photo */}
           <div className="mb-6 flex flex-col items-center gap-3 sm:flex-row sm:gap-6">
             <div className="relative shrink-0">
-              <img
-                src={currentAvatarSrc ?? "/default-avatar.png"}
-                alt={user?.name ?? "Avatar"}
-                className="h-20 w-20 rounded-full object-cover sm:h-24 sm:w-24"
-              />
+              {currentAvatarSrc ? (
+                <img
+                  src={currentAvatarSrc}
+                  alt={user?.name ?? "Avatar"}
+                  className="h-20 w-20 rounded-full object-cover sm:h-24 sm:w-24"
+                />
+              ) : (
+                <Avatar name={user?.name} size={96} />
+              )}
               {photoLoading && (
                 <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/30">
                   <svg


### PR DESCRIPTION
## Summary

- Replaces the `default-avatar.png` fallback with the `<Avatar>` initials component when no profile photo has been uploaded
- Matches the spec in `specs/profile.md` §4 (Fallback) and resolves the gap found in the post-build audit
- No behaviour change for users who have already uploaded a photo

## How to test manually

**Fallback (no photo uploaded)**
1. Log in and go to `/profile`
2. If you have a photo uploaded, skip to the reset step below
3. Confirm the avatar area shows your initials in a circle (e.g. "SS" for Shubham Sarda), not the grey silhouette image

**After uploading a photo**
1. On `/profile`, click **Change photo** and select a JPEG/PNG
2. Confirm the optimistic preview shows your photo immediately
3. After upload completes, confirm the photo persists on page reload

**Resetting to initials fallback**
1. In the Supabase dashboard → Storage → `avatars` bucket, delete your file (named by your user UUID)
2. In Table Editor → `users`, clear the `avatar_url` value for your row
3. Hard-reload `/profile` — initials should reappear

**Header**
1. Confirm the avatar in the top-right navbar trigger also shows your photo when uploaded, or falls back to initials when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)