### PR TITLE
Add tab navigation to Dashboard for active/settled groups

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,15 +1,16 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { useAuth } from "../context/useAuth";
 import { storage } from "../data/storage";
-import { userBalanceInGroup } from "../lib/balances";
+import { calculateNetBalances, userBalanceInGroup } from "../lib/balances";
 import { formatCurrency } from "../lib/format";
 import AppHeader from "../components/AppHeader";
 
 export default function Dashboard() {
   const { user } = useAuth();
   const location = useLocation();
+  const [tab, setTab] = useState("active");
 
   // Re-derive data whenever the component mounts/re-mounts (e.g. navigating
   // back from GroupDetail after a settlement). location.key changes on every
@@ -25,7 +26,12 @@ export default function Dashboard() {
         user.id,
         settlements,
       );
-      return { group: g, balance };
+      // A group is settled only when it has expenses and all member balances are zero.
+      const allBalances = calculateNetBalances(expenses, g.members, settlements);
+      const hasExpenses = expenses.length > 0;
+      const allZero = Object.values(allBalances).every((b) => Math.abs(b) < 0.01);
+      const isSettled = hasExpenses && allZero;
+      return { group: g, balance, isSettled };
     });
     let owed = 0;
     let owe = 0;
@@ -33,9 +39,13 @@ export default function Dashboard() {
       if (c.balance > 0) owed += c.balance;
       else if (c.balance < 0) owe += -c.balance;
     }
-    return { cards, owed, owe, net: owed - owe };
+    const activeCards = cards.filter((c) => !c.isSettled);
+    const settledCards = cards.filter((c) => c.isSettled);
+    return { cards, activeCards, settledCards, owed, owe, net: owed - owe };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user.id, location.key]); // location.key is a cache-buster: forces re-read from storage on every navigation
+
+  const visibleCards = tab === "active" ? data.activeCards : data.settledCards;
 
   return (
     <div className="min-h-screen bg-canvas">
@@ -67,13 +77,51 @@ export default function Dashboard() {
         {data.cards.length === 0 ? (
           <EmptyState />
         ) : (
-          <section className="space-y-2">
-            {data.cards.map(({ group, balance }) => (
-              <GroupCard key={group.id} group={group} balance={balance} />
-            ))}
-          </section>
+          <>
+            <Tabs
+              tab={tab}
+              setTab={setTab}
+              activeCount={data.activeCards.length}
+              settledCount={data.settledCards.length}
+            />
+            <section className="space-y-2">
+              {visibleCards.length === 0 ? (
+                <p className="text-sm text-ink-muted text-center py-8">
+                  {tab === "active" ? "No active groups." : "No settled groups yet."}
+                </p>
+              ) : (
+                visibleCards.map(({ group, balance }) => (
+                  <GroupCard key={group.id} group={group} balance={balance} />
+                ))
+              )}
+            </section>
+          </>
         )}
       </main>
+    </div>
+  );
+}
+
+function Tabs({ tab, setTab, activeCount, settledCount }) {
+  const base =
+    "px-4 py-2 text-sm font-semibold border-b-2 transition-colors focus:outline-none";
+  const active = "border-[#EA580C] text-[#EA580C]";
+  const inactive = "border-transparent text-ink-muted hover:text-ink";
+
+  return (
+    <div className="flex border-b border-border">
+      <button
+        className={`${base} ${tab === "active" ? active : inactive}`}
+        onClick={() => setTab("active")}
+      >
+        Active ({activeCount})
+      </button>
+      <button
+        className={`${base} ${tab === "settled" ? active : inactive}`}
+        onClick={() => setTab("settled")}
+      >
+        Settled ({settledCount})
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Added tab-based filtering to the Dashboard to separate active groups from settled groups, improving visibility and organization of group statuses.

## Key Changes
- **Settlement detection**: Added logic to determine if a group is settled by checking if it has expenses and all member balances are zero (within 0.01 tolerance)
- **Tab state management**: Introduced `tab` state to track which view the user is on ("active" or "settled")
- **Data filtering**: Split the cards list into `activeCards` and `settledCards` based on settlement status
- **Tab UI component**: Created a new `Tabs` component with styled buttons showing counts for each tab
- **Empty state messaging**: Added contextual empty state messages for each tab ("No active groups." / "No settled groups yet.")
- **Import updates**: Added `calculateNetBalances` import from `src/lib/balances.js` to support settlement detection

## Implementation Details
- Settlement status is calculated using `calculateNetBalances()` to get all member balances, then checking if all balances are near-zero (using `Math.abs(b) < 0.01` to handle floating-point precision)
- A group is considered settled only if it has at least one expense AND all member balances are zero
- Tab styling uses the existing design system (orange accent color `#EA580C` for active tab, muted text for inactive)
- The visible cards list is computed based on the current tab selection

https://claude.ai/code/session_01KSQzzccq4BSeQpmmpuvaxN