### PR TITLE
Add member to group by email from group settings

### DIFF
--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -371,6 +371,37 @@ export const storage = {
     group.budget = normalized;
   },
 
+  // Add a member to an existing group by email. If the email belongs to a
+  // registered user, they are added as active; otherwise as pending.
+  async addMember(groupId, email) {
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed) throw new Error("Email cannot be empty.");
+
+    const group = _groups.find((g) => g.id === groupId);
+    if (!group) throw new Error("Group not found.");
+
+    if (group.members.some((m) => m.email === trimmed)) {
+      throw new Error("This person is already a member of this group.");
+    }
+
+    const existing = this.getUserByEmail(trimmed);
+    const member = existing
+      ? { userId: existing.id, email: existing.email, name: existing.name, status: "active" }
+      : { userId: null, email: trimmed, name: null, status: "pending" };
+
+    const { error } = await supabase.from("group_members").insert({
+      group_id: groupId,
+      user_id: member.userId,
+      email: member.email,
+      name: member.name,
+      status: member.status,
+    });
+    if (error) throw error;
+
+    group.members.push(member);
+    return member;
+  },
+
   // Remove a member from a group — deletes from `group_members` and removes
   // from the in-memory cache.  Callers must verify the member has no expense
   // involvement before calling this.

--- a/src/pages/GroupSettings.jsx
+++ b/src/pages/GroupSettings.jsx
@@ -43,6 +43,7 @@ export default function GroupSettings() {
 
         <RenameSection group={group} onRenamed={refresh} />
         <BudgetSection group={group} onUpdate={refresh} />
+        <AddMemberSection group={group} onAdded={refresh} />
         <MembersSection
           group={group}
           currentUserId={user.id}
@@ -186,6 +187,80 @@ function BudgetSection({ group, onUpdate }) {
           className="btn-primary disabled:opacity-60"
         >
           {status === "saving" ? "Saving…" : "Save budget"}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add member section
+// ---------------------------------------------------------------------------
+
+function AddMemberSection({ group, onAdded }) {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState(null); // null | 'saving' | 'success' | 'error'
+  const [errorMsg, setErrorMsg] = useState("");
+  const [addedEmail, setAddedEmail] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed) {
+      setErrorMsg("Please enter an email address.");
+      setStatus("error");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setErrorMsg("Please enter a valid email address.");
+      setStatus("error");
+      return;
+    }
+    setStatus("saving");
+    setErrorMsg("");
+    try {
+      await storage.addMember(group.id, trimmed);
+      setAddedEmail(trimmed);
+      setEmail("");
+      setStatus("success");
+      onAdded();
+    } catch (err) {
+      setErrorMsg(err.message || "Failed to add member. Please try again.");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <section className="card space-y-4">
+      <SectionLabel>Add member</SectionLabel>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <label className="block">
+          <span className="field-label">Email address</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setStatus(null);
+            }}
+            placeholder="friend@example.com"
+            className="field"
+          />
+        </label>
+        {status === "error" && (
+          <p className="text-sm text-danger">{errorMsg}</p>
+        )}
+        {status === "success" && (
+          <p className="text-sm text-pos">
+            {addedEmail} added to the group.
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={status === "saving"}
+          className="btn-primary disabled:opacity-60"
+        >
+          {status === "saving" ? "Adding…" : "Add member"}
         </button>
       </form>
     </section>


### PR DESCRIPTION
## Summary
Adds functionality to invite members to a group by email address directly from the Group Settings page. Members can be added whether or not they have registered with Splitmate yet.

## Changes
- **GroupSettings.jsx**: Added `AddMemberSection` component that provides a form to invite members by email
  - Validates email format before submission
  - Shows loading state while adding member
  - Displays success/error messages to the user
  - Clears form on successful addition and triggers parent refresh
  
- **storage.js**: Implemented `addMember(groupId, email)` method
  - Validates email and checks for duplicates within the group
  - Looks up registered users by email; adds as "active" if found, otherwise as "pending"
  - Persists to Supabase `group_members` table
  - Updates in-memory cache on success

## Implementation Details
- Email validation uses a basic regex pattern (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`)
- Pending members (unregistered emails) are stored with `userId: null` and `status: "pending"`, allowing them to be upgraded when they later register
- The component integrates with the existing `refresh` callback pattern used by other settings sections
- Error handling covers empty input, invalid format, duplicate members, and Supabase failures

https://claude.ai/code/session_01DNNjdUF6Z3DPLUU2fQRVVv